### PR TITLE
interactive commit viz

### DIFF
--- a/build/pandoc/defaults/html.yaml
+++ b/build/pandoc/defaults/html.yaml
@@ -23,6 +23,7 @@ include-after-body:
 - build/plugins/hypothesis.html
 - build/plugins/mathjax.html
 #- build/plugins/scite.html
+- build/plugins/vega-lite.html
 variables:
   document-css: false
   math: ""

--- a/build/plugins/vega-lite.html
+++ b/build/plugins/vega-lite.html
@@ -1,0 +1,25 @@
+<!--
+  vega-lite Plugin (third-party) 
+  
+  Allows you to use a declarative grammar to describe interactive visualizations.
+  See https://vega.github.io/
+-->
+
+<script
+  src="https://cdnjs.cloudflare.com/ajax/libs/vega/5.22.0/vega.min.js"
+  integrity="sha512-joOH8OWtFZARB3BwtOpZA07Leh8g6lRL2TtpURT2u6qZUQpYHux5e54v4saIQ7VAhnLRL3xHplO48eF/7Li5NA=="
+  crossorigin="anonymous"
+  referrerpolicy="no-referrer"
+></script>
+<script
+  src="https://cdnjs.cloudflare.com/ajax/libs/vega-lite/5.2.0/vega-lite.min.js"
+  integrity="sha512-GPC1fKIzfK/w1ufw45IkI0Wz+CKgz/VqiCsG0JYNG3Cbr7MDz0pbRzUFpluU878tZ0wZeDRScHhIFm9oDtMydQ=="
+  crossorigin="anonymous"
+  referrerpolicy="no-referrer"
+></script>
+<script
+  src="https://cdnjs.cloudflare.com/ajax/libs/vega-embed/6.20.8/vega-embed.min.js"
+  integrity="sha512-gDoPz1IHkL4uyxS/lm91VeojC0u8Y1sg1CRd3mQKgUgKzrwzmpX0X3olKP0r3O6tyQFSDnsw3MGZCPDkWObvUQ=="
+  crossorigin="anonymous"
+  referrerpolicy="no-referrer"
+></script>

--- a/content/15.development_procedure.md
+++ b/content/15.development_procedure.md
@@ -14,7 +14,84 @@ This three-pronged approach generally has suited the community; the process of b
 However, balancing the needs of a community requiring stable methods for analyzing data against the ease of development suggests that this is a toll worth paying.
 
 In general, the development of `yt` is reasonably top-heavy, with the majority of contributions coming from a core group of individuals.
-We discuss the implications of this on sustainability in Section [sec:sustainability].
+We discuss the implications of this on sustainability in Section [sec:sustainability], and provide here a graph of the contributions over time.
+
+<div id="figure-commit-graph"></div>{#fig:commit-graph}
+
+<script>
+var commitGraphSpecification = {
+  "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+  "data": {"url": "images/yt_repo.json"},
+  "transform": [
+    {
+      "timeUnit": "yearquarter",
+      "field": "committed_datetime",
+      "as": "commit_quarter"
+    },
+    {
+      "aggregate": [{"op": "count", "as": "count"}],
+      "groupby": ["commit_quarter", "author"]
+    }
+  ],
+  "hconcat": [
+    {
+      "params": [{"name": "commit_range", "select": {"type": "interval", "encodings": ["x"]}}],
+      "mark": "bar",
+      "encoding": {
+        "y": {
+          "aggregate": "sum",
+          "field": "count",
+          "type": "quantitative",
+          "axis": {"title": "# commits"}
+        },
+        "x": {
+          "field": "commit_quarter",
+          "type": "temporal",
+          "scale": {"padding": 0}
+        }
+      }
+    },
+    {
+      "transform": [
+        {"filter": {"param": "commit_range"}},
+        {
+          "aggregate": [{"op": "sum", "field": "count", "as": "author_count"}],
+          "groupby": ["author"]
+        },
+        {
+          "window": [{"op": "rank", "as": "rank"}],
+          "sort": [{"order": "descending", "field": "author_count"}]
+        },
+        {"filter": {"field": "rank", "lte": 10}},
+        {"calculate": "split(datum['author'], ' <', 1)[0]", "as": "author_name"}
+      ],
+      "mark": {"type": "bar"},
+      "encoding": {
+        "y": {
+          "field": "author_name",
+          "type": "nominal",
+          "axis": {"title": "top 10 authors"},
+          "sort": {"order": "ascending", "field": "rank"}
+        },
+        "x": {
+          "type": "quantitative",
+          "field": "author_count",
+          "scale": {"domain": [0, 9000]},
+          "axis": {"title": "number of commits"}
+        }
+      }
+    }
+  ],
+  "config": {
+    "axis": {"labelFontSize": 16, "titleFontSize": 16},
+    "legend": {"labelFontSize": 16, "titleFontSize": 16}
+  }
+};
+
+vegaEmbed('#figure-commit-graph', commitGraphSpecification);
+
+
+</script>
 
 ### Unit Testing {#sec:unit_testing}
 

--- a/scripts/generate_yt_stats.py
+++ b/scripts/generate_yt_stats.py
@@ -1,0 +1,43 @@
+# Meant to be run from the root yt-4.0-paper directory, which should live next to a yt directory.
+
+mapping = {}
+
+repo_loc = "../yt/"
+
+with open(repo_loc + ".mailmap", 'r') as mailmap:
+    for line in mailmap.readlines():
+        try:
+            val, key = line.split('>', 1)
+            key = key.strip()
+            val = val.strip() + '>'
+            mapping[key] = val
+        except ValueError:
+            print(line)
+
+import pandas as pd
+import git
+
+yt_repo = git.repo.Repo(repo_loc)
+
+attributes = ("author", "committed_datetime", "hexsha")
+
+data = {_:[] for _ in attributes}
+
+for i, c in enumerate(yt_repo.iter_commits()):
+    if i % 1000 == 0:
+        print(i)
+    for attr in attributes:
+        data[attr].append(getattr(c, attr))
+
+new_authors = []
+for author in data["author"]:
+    author_str = f"{author.name} <{author.email}>"
+    try:
+        author_str = mapping[author_str]
+    except KeyError:
+        pass
+    new_authors.append(author_str)
+        
+data["author"] = new_authors
+df = pd.DataFrame(data)
+df.to_json("content/images/yt_repo.json", orient="records")


### PR DESCRIPTION
This is a quick, first-pass at an interactive commit history viz.  I think we may end up wanting to remove the `.json` file at some point (possibly while squashing this?) and have it pull the appropriate info during the build phase, but I think that may also be tricky to do with the process of cloning etc.
