### PR TITLE
Add OS as author

### DIFF
--- a/content/metadata.yaml
+++ b/content/metadata.yaml
@@ -207,7 +207,16 @@ authors:
     affiliations:
       - Department of Physics, Kavli Institute for Astrophysics and Space Research, Massachusetts Institute of Technology, Cambridge, MA 02139, USA
     funders: []
-   -
+  -
+    github: olebole
+    name: Ole Streicher
+    initials: OS
+    orcid: 0000-0001-7751-1843
+    email: ole@aip.de
+    affiliations:
+      - Leibniz Institute for Astrophysics Potsdam (AIP)
+    funders: []
+  -
     github: yournamehere
     name: Add Yourself
     initials: YOU


### PR DESCRIPTION
I am doing the regular Debian packaging for yt and related packages (unyt, cmyt) since ~2018. As this is a bit outside of the focus of the paper, I am afraid that I can't contribute much, and I am also not sure if this is considered enough to be a co-author. For the case it is, here is my authorship entry.
