### PR TITLE
revise citation to Jacquemin-Ide 2021

### DIFF
--- a/content/30.abstracting_simulation_types.md
+++ b/content/30.abstracting_simulation_types.md
@@ -288,5 +288,6 @@ This dataset, a simulation of magnetically-driven winds in a protoplanetary disk
 Here, we have used `yt`'s functionality for overplotting streamlines as well as line integral convolution on irregular meshes to display the data in its native resolution and as a slice along the azimuthal axis of the simulation domain.
 
 ![
-Spherical data from a protoplanetary disk, overlaid with annotations supplied by `yt` to demonstrate both the magnetic field and velocity structure of the data.  Data are used, with permission, from the simulations described in [@doi:10.1051/0004-6361/202039322].
+Spherical data from a protoplanetary disk, overlaid with annotations supplied by `yt` to demonstrate both the magnetic field and velocity structure of the data. 
+Data are used, with permission, from a simulation based on the ones described in [@doi:10.1051/0004-6361/202039322].
 ](images/spherical_data.png){#fig:spherical_data}


### PR DESCRIPTION
follow up to #141

make it clearer that we are not using the original data from the paper, but a new simulation.
For context, the original paper uses PLUTO while the actual dataset used for illustration was produced with Idefix. 