### PR TITLE
Changed SPH description to include wider context

### DIFF
--- a/content/30.abstracting_simulation_types.md
+++ b/content/30.abstracting_simulation_types.md
@@ -131,21 +131,28 @@ Scheme of the AMR structure used to estimate the gradient of a quantity in the c
 Smoothed Particle Hydrodynamics (SPH) is a commonly-used method for solving equations of hydrodynamics in astrophysics (as well as many other fields!) from a lagrangian perspective.
 This provides many advantages over grid-based discretizations, but also poses somewhat different challenges for analysis and visualization.
 While a full description of SPH is outside the scope of this paper, there are a handful of crucial and important pieces of information that we will review.
-For more information, we refer interested readers to this comprehensive review of Smoothed Particle Hydrodynamics by Volker Springel [@doi:10.1146/annurev-astro-081309-130914] or to the SPLASH method paper by Daniel Price [@doi:10.1071/AS07022].
-SPH defines field quantities *at* a set of moving points, and field values at any point (i.e., between the points) can be computed by integrating over all the elements in the domain using a special-purpose kernel; this method is an exact interpolation between the discretized points by applying the smoothing kernel.
+For more information, we refer interested readers to this comprehensive review of Smoothed Particle Hydrodynamics by Daniel Price [@doi:10.1016/j.jcp.2010.12.011], the one by Volker Springel [@doi:10.1146/annurev-astro-081309-130914], or to the SPLASH method paper by Daniel Price [@doi:10.1071/AS07022].
+SPH defines field quantities *at* a set of moving points, allowing generic field values (i.e., between the points) to be computed by integrating over all the elements in the domain using a special-purpose kernel; this method is an exact interpolation between the discretized points by applying the smoothing kernel.
 Formally, this is represented as:
 $$
 A(\mathbf{r}) = \int A(\mathbf{r}')W(|\mathbf{r} - \mathbf{r}'|,h)\mathrm{d}V(\mathbf{r}')
 $$
 This is then reduced to a sum over the particles (the discretization points):
 $$
-A(\mathbf{r}) = \sum_j V_j A_j W(|\mathbf{r} - \mathbf{r}'|, h)
+A(\mathbf{r}, h) = \sum_j V_j A_j W(|\mathbf{r} - \mathbf{r}_j|, h)
 $$
 In these equations, $A$ is the field, W is the weighting function (the 'kernel') and $h$ is the smoothing length.
-(One important note is that for various reasons, the smoothing length and the 'half' smoothing length are often used in different contexts in SPH; this is something to keep in mind, as variable names such as `hsml` may in fact refer to 'half-smoothing length.')
-By choosing a smoothing kernel that terminates outside of a given radius, this can be restricted to a finite subset of the number of particles in the simulation, and provide a natural adaptivity in resolution.
-One common approach is to define the field values in terms of the N nearest neighboring particles; often this is a power of two, such as 32 or 64, which can be identified using a spatial search such as a kD-tree.
-There are other formulations of SPH as well that confine the integral to a fixed number of particles, that evaluate based on pressure criteria, and so forth.
+This weighting function typically takes the shape of a Gaussian, approximated through various spline functions (truncated at some radius), but that is not strictly necessary [@doi:10.1111/j.1365-2966.2012.21439.x].
+The quantity $h$, the smoothing length, has previously been referred to as the 'half-smoothing length' (hence the variable name `hsml` used in many contexts), but formally represents the full-width-half-maximum of the Gaussian approximated by the spline kernels, with the ratio $\ell_{\rm FWHM} / h = \sqrt{2\ln2}$ [@doi:10.1093/mnras/stab1423].
+The value of $h$ in adaptive simulations is typically allowed to vary (which is extremely common in astronomy, though this is not true when SPH is applied to other domains where the density of the fluid remains roughly fixed) such that a constraint equation, e.g.
+$$
+  n(\mathbf{r}, h_i) = \sum_j W(|\mathbf{r} - \mathbf{r}_j|, h_i) = \left(\frac{\eta}{h_i}\right)^{n_{\rm D}},
+$$
+is satisfied, where $\eta$ is a fixed constant that sets the spatial resolution of the simulation and $n_{\rm D}$ is the number of dimensions.
+Various codes may change this constraint equation for differing purposes, such as confining the integral to a fixed number of particles, or those that evaluate the constraint based on pressure criteria, and so forth.
+Many codes store the maximal radial extent of the kernel (known as the kernel extent, and often represented by $H$), as this is what is used in neighbour finding operations.
+The drawback to this choice is that the specific value of $H$ is kernel-dependent, as some may cut off at much shorter distances than others when representing the same Gaussian.
+As different codes and methods make use of different kernels for various reasons (ones with larger cut-off radii can produce less noisy results, but are computationally more costly), some codes now employ $h=H/\gamma_{\rm K}$, where $\gamma_{\rm K}$ is a kernel-dependent quantity.
 
 In general, there are two approaches to defining the finite set of particles that contribute to a field at a given point.
 In "scatter" methods, computing a field at a given point is conducted by iterating over particles and identifying those whose smoothing length overlaps with a given point.
@@ -153,7 +160,6 @@ In the alternate method "gather," the outer and inner loops of the algorithm are
 
 For the purposes of *post-processing* analysis and visualization, the most important criteria for applying SPH to a set of particles are to ensure that the function that computes field values at a given location is *identical* to that used inside the simulation code (or as close as possible) and that the calculations are conducted in as short a time as possible.
 This set of dual requirements has led to yt implementing a flexible system for defining the smoothing kernel used, whether or not a normalization step is applied to SPH quantities, and the option to use either "scatter" or "gather" methods for computing field values at fixed locations.
-
 
 Previous versions of `yt` provided analysis of SPH data through a hybrid approach that mixed pure-SPH analysis with octree-based gridding and indexing that used particle density as a guide for the necessary resolution.
 Although the present, yt 4.0 series does not utilize octrees for particles, a description of the previous implementation is useful to provide both historical information and modern motivation for the "demeshening" initiative that led to the current code base.


### PR DESCRIPTION
I've corrected a couple of things in the SPH section. I've also changed the recommended review to Price+ as this is more generic (i.e. applicable to more than just galaxy formation) than the one by Springel, though I have left that reference.