### PR TITLE
adding closing time figure and updating VL

### DIFF
--- a/build/plugins/vega-lite.html
+++ b/build/plugins/vega-lite.html
@@ -6,20 +6,20 @@
 -->
 
 <script
-  src="https://cdnjs.cloudflare.com/ajax/libs/vega/5.22.0/vega.min.js"
-  integrity="sha512-joOH8OWtFZARB3BwtOpZA07Leh8g6lRL2TtpURT2u6qZUQpYHux5e54v4saIQ7VAhnLRL3xHplO48eF/7Li5NA=="
+  src="https://cdnjs.cloudflare.com/ajax/libs/vega/5.25.0/vega.min.js"
+  integrity="sha512-XX9YBZNtGu/Bz3d3zstE6vcEf4coHTGyxTwzU+0DNR7kHoD37krFcyWnqKTdzV6yWS9a5g3H3a71bM4ctzE1kA=="
   crossorigin="anonymous"
   referrerpolicy="no-referrer"
 ></script>
 <script
-  src="https://cdnjs.cloudflare.com/ajax/libs/vega-lite/5.2.0/vega-lite.min.js"
-  integrity="sha512-GPC1fKIzfK/w1ufw45IkI0Wz+CKgz/VqiCsG0JYNG3Cbr7MDz0pbRzUFpluU878tZ0wZeDRScHhIFm9oDtMydQ=="
+  src="https://cdnjs.cloudflare.com/ajax/libs/vega-lite/5.14.1/vega-lite.min.js"
+  integrity="sha512-tOoHntHr+Zq7t/jBpDkIQJG6q+fWZVzoSNOpoU4g+TEh4I4cTZuCPNSLGXP9KC9mWSyQ8QMEem8PMHSX9zPq9w=="
   crossorigin="anonymous"
   referrerpolicy="no-referrer"
 ></script>
 <script
-  src="https://cdnjs.cloudflare.com/ajax/libs/vega-embed/6.20.8/vega-embed.min.js"
-  integrity="sha512-gDoPz1IHkL4uyxS/lm91VeojC0u8Y1sg1CRd3mQKgUgKzrwzmpX0X3olKP0r3O6tyQFSDnsw3MGZCPDkWObvUQ=="
+  src="https://cdnjs.cloudflare.com/ajax/libs/vega-embed/6.22.2/vega-embed.min.js"
+  integrity="sha512-XGkG4fTLMPA3Lp9FUGv7MFNvzpAzC/QgC//cOSxjfhmj8fZjF8iyqn9rgXjwHiY1xqWFzn+BnH8R0oGClEIPvw=="
   crossorigin="anonymous"
   referrerpolicy="no-referrer"
 ></script>

--- a/content/15.development_procedure.md
+++ b/content/15.development_procedure.md
@@ -21,12 +21,8 @@ Recent practice, however, is more inclined toward commit "squashing," where mult
 One result of this is in figures such as the top row of Figure @fig:commit-graph, some contributors appear to have made a smaller quantity of contributions than an informed observer would recognize.
 Specifically, this applies to Clément Robert, who has contributed a considerable amount of change to the code base but has done so in a way that does not maximize the "statistics" presented below.
 This particular bias, toward contributions measured in count, is one that affects other members of the community as well, especially those whose participation is through community engagement, documentation, tutorials, and mentoring, rather than through direct modifications of the code base.
-
 To mitigate this shortcoming, we present the number of pull requests merged into the code base, as a function of time, as well as the time between their creation and their merge, in the lower row of Figure @fig:figure-commit-graph.
 This demonstrates that in many cases, the number of discrete contributions to the codebase varies greatly depending on the developer, and we believe gives a more informed perception of the activity in the code base.
-The longest time between opening a pull request and merging it was nearly four years; this was the addition of the `cf_radial` frontend, which occurred in fits and starts over a very long period of time.
-The next longest pull request durations are for splitting the code used for bitmap indexing (see @sec:point_indexing) and a per-field configuration system.
-This includes only those pull requests that occurred on GitHub.
 
 <div id="figure-commit-graph"></div>
 
@@ -37,6 +33,22 @@ Commits and pull requests to the source code as a function of time.
 <script>
 vegaEmbed('#figure-commit-graph', "images/yt_repo.vl");
 </script>
+
+In Figure @fig:pr-closing-time we have plotted distribution of pull requests based on the time between their creation and their merge.
+The longest time between opening a pull request and merging it was nearly four years; this was the addition of the `cf_radial` frontend, which occurred in fits and starts over a very long period of time.
+The next longest pull request durations are for splitting the code used for bitmap indexing (see @sec:point_indexing) and a per-field configuration system.
+This includes only those pull requests that occurred on GitHub.
+
+<div id="figure-pr-closing-time"></div>
+
+![
+The distribution of pull requests as a function of how long it took to close them.
+](images/blank.svg){#fig:pr-closing-time width="1px"}
+
+<script>
+vegaEmbed('#figure-pr-closing-time', "images/pr_stats.vl");
+</script>
+
 
 ### Unit Testing {#sec:unit_testing}
 

--- a/content/images/pr_times.vl
+++ b/content/images/pr_times.vl
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+  "data": {
+    "url": "./yt_repo.csv"
+  },
+  "transform": [
+    {"filter": {"field": "type", "equal": "pull-request"}},
+    {"timeUnit": "yearquarter", "field": "datetime", "as": "quarter"}
+  ],
+  "vconcat": [
+    {
+      "mark": "tick",
+      "params": [
+        {
+          "name": "commit_range",
+          "select": {"type": "interval", "encodings": ["x"]}
+        }
+      ],
+      "encoding": {
+        "x": {
+          "field": "datetime",
+          "type": "temporal",
+          "axis": {"title": null, "orient": "top"}
+        },
+        "opacity": {"value": 0.05}
+      }
+    },
+    {
+      "transform": [
+        {"filter": {"param": "commit_range"}},
+        {"calculate": "log(datum.duration)/log(10)", "as": "log_duration"},
+        {
+          "bin": {"base": 10, "extent": [2, 8.2], "step": 0.25},
+          "field": "log_duration",
+          "as": "bin_log_duration"
+        },
+        {"calculate": "pow(10, datum.bin_log_duration)", "as": "x1"},
+        {"calculate": "pow(10, datum.bin_log_duration_end)", "as": "x2"}
+      ],
+      "layer": [
+        {
+          "mark": "bar",
+          "encoding": {
+            "y": {
+              "field": "x1",
+              "scale": {"type": "log", "base": 10, "domain": [100, 100000000]},
+              "axis": {"tickCount": 5, "title": "Seconds to Merge"},
+              "type": "quantitative"
+            },
+            "y2": {"field": "x2"},
+            "x": {
+              "aggregate": "count",
+              "scale": {"type": "linear", "domain": [0, 250]}
+            }
+          }
+        },
+        {
+          "data": {
+            "values": [
+              {"t": 3600, "label": "1h", "y": 1},
+              {"t": 86400, "label": "1d", "y": 1},
+              {"t": 604800, "label": "1w", "y": 1},
+              {"t": 2592000, "label": "1m", "y": 1},
+              {"t": 31536000, "label": "1y", "y": 1}
+            ]
+          },
+          "resolve": {"scale": {"x": "independent"}},
+          "layer": [
+            {
+              "mark": "rule",
+              "encoding": {
+                "y": {"field": "t", "type": "quantitative"},
+                "color": {"value": "black"}
+              }
+            },
+            {
+              "mark": {
+                "type": "text",
+                "angle": 0,
+                "align": "left",
+                "dy": 0,
+                "dx": 5,
+                "baseline": "middle"
+              },
+              "encoding": {
+                "y": {"field": "t", "type": "quantitative"},
+                "text": {"field": "label"},
+                "x": {
+                  "field": "y",
+                  "scale": {"domain": [0, 1]},
+                  "type": "quantitative",
+                  "axis": {"title": "# of merged pull requests"}
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/content/images/yt_repo.vl
+++ b/content/images/yt_repo.vl
@@ -1,4 +1,3 @@
-
 {
   "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
   "data": {


### PR DESCRIPTION
Vega-lite needed an update, so I updated the plugin, and I added a new figure that shows how long it takes for PRs to be closed.
