### PR TITLE
fix mpl figure handle access

### DIFF
--- a/scripts/finite_element_zoomin_plot.py
+++ b/scripts/finite_element_zoomin_plot.py
@@ -21,4 +21,4 @@ bounds = s2.xlim[0], s2.ylim[0], s2.xlim[1]-s2.xlim[0], s2.ylim[1]-s2.ylim[0]
 rect, conn = s1.plots["all", "ux"].axes.indicate_inset(bounds, s2_ax, edgecolor='k', linewidth=1.0)
 conn[0].set_visible(True)
 conn[1].set_visible(True)
-s1.plots["all", "ux"].savefig("fem_example.png")
+s1.plots["all", "ux"].figure.savefig("fem_example.png")


### PR DESCRIPTION
Just tried to run `scripts/finite_element_zoomin_plot.py` and got an error:

```python-traceback
Traceback (most recent call last):
  File "/home/chavlin/src/yt_general/website_explore/yt-4.0-paper/scripts/finite_element_zoomin_plot.py", line 24, in <module>
    s1.plots["all", "ux"].savefig("fem_example.png")
AttributeError: 'WindowPlotMPL' object has no attribute 'savefig'
```
There is a `WindowPlotMPL.save`, but I went with pulling out the handle to the matplotlib figure to use `savefig` in this PR. 