### PR TITLE
Updating to recent rootstock

### DIFF
--- a/.github/workflows/manubot.yaml
+++ b/.github/workflows/manubot.yaml
@@ -85,7 +85,7 @@ jobs:
           restore-keys: |
             ci-cache-${{ env.DEFAULT_BRANCH_REF }}
       - name: Anaconda cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         env:
           # Increase this value to reset cache if etc/example-environment.yml has not changed
           CACHE_NUMBER: 0

--- a/build/README.md
+++ b/build/README.md
@@ -32,7 +32,7 @@ To change the options, either edit the YAML files directly or add additional `--
 Note: currently, **Windows is not supported**.
 
 The Manubot environment is managed with [conda](https://conda.io).
-If you do not have `conda` installed, we recommend using the Miniforge3 (includes `conda`) or Mambaforge (includes `conda` and `mamba`) installers from [miniforge](https://github.com/conda-forge/miniforge).
+If you do not have `conda` installed, we recommend using the Miniforge3 installer from [miniforge](https://github.com/conda-forge/miniforge) (includes `conda` and `mamba`).
 Install the environment from [`environment.yml`](environment.yml) by running one of following commands
 (from the repository's root directory):
 

--- a/ci/install-spellcheck.sh
+++ b/ci/install-spellcheck.sh
@@ -6,7 +6,8 @@
 set -o errexit \
     -o pipefail
 
-sudo apt-get update --yes
+# --allow-releaseinfo-change for error on appveyor like "Repository ... changed its 'Label' value"
+sudo apt-get update --yes --allow-releaseinfo-change
 sudo apt-get install --yes aspell aspell-en
 wget --directory-prefix=build/pandoc/filters \
   https://github.com/pandoc/lua-filters/raw/13c3fa7e97206413609a48a82575cb43137e037f/spellcheck/spellcheck.lua

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -7,7 +7,7 @@
 set -o errexit \
     -o pipefail
 
-wget https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-$(uname)-$(uname -m).sh \
+wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh \
   --output-document miniforge.sh
 bash miniforge.sh -b -p $HOME/miniconda
 source $HOME/miniconda/etc/profile.d/conda.sh


### PR DESCRIPTION
merges https://github.com/manubot/rootstock/pull/521

* replace all mambaforge with miniforge
   closes https://github.com/manubot/rootstock/issues/519

* ci/install-spellcheck.sh: fix appveyor error
   from https://ci.appveyor.com/project/manubot/rootstock/builds/51206619#L577
   E: Repository 'http://ppa.launchpad.net/rabbitmq/rabbitmq-erlang/ubuntu jammy InRelease' changed its 'Label' value from 'Latest (26.x) Erlang packages for Ubuntu and Debian' to 'Modern Erlang and Elixir packages for Ubuntu'
   N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.